### PR TITLE
Restrict activity choices in event management

### DIFF
--- a/collectives/forms.py
+++ b/collectives/forms.py
@@ -38,9 +38,9 @@ class EventForm(ModelForm, FlaskForm):
     photo_file = FileField(validators=[FileAllowed(photos, 'Image only!')])
     type = SelectField('Type', choices=[])
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, activity_choices, *args, **kwargs):
         super(EventForm, self).__init__(*args, **kwargs)
-        self.type.choices = [(a.id, a.name) for a in ActivityType.query.all()]
+        self.type.choices = activity_choices
 
 
 class AdminUserForm(ModelForm, FlaskForm):


### PR DESCRIPTION
Affiche seulement les activités que l'utilisateur peut encadrer

Carte trello https://trello.com/c/Ir9TZkdu/95-cr%C3%A9ation-collective-nafficher-que-les-activit%C3%A9s-quun-encadrant-ne-peut-encadrer