### PR TITLE
Event list: avec tabulator

### DIFF
--- a/collectives/event.py
+++ b/collectives/event.py
@@ -30,11 +30,10 @@ def activity_choices(activities, leaders):
 @blueprint.route('/index')
 @blueprint.route('/list')
 def index():
-    events = Event.query.filter(Event.end >= date.today()
-                                ).order_by(Event.start).all()
+    types = ActivityType.query.all()
     return render_template('index.html',
                            conf=current_app.config,
-                           events=events,
+                           types=types,
                            photos=photos)
 
 

--- a/collectives/models.py
+++ b/collectives/models.py
@@ -171,6 +171,9 @@ class User(db.Model, UserMixin):
                                            RoleIds.ActivitySupervisor],
                                           activity_id)
 
+    def can_read_other_users(self):
+        return len(self.roles) > 0
+
     def supervises_activity(self, activity_id):
         return self.has_role_for_activity([RoleIds.ActivitySupervisor],
                                           activity_id)

--- a/collectives/static/caf/icon/activity.css
+++ b/collectives/static/caf/icon/activity.css
@@ -13,6 +13,10 @@ span.activity.s30px{
   height: 30px !important;
   width: 30px !important;
 }
+span.activity.s20px{
+  height: 20px !important;
+  width: 20px !important;
+}
 
 /* Premiere ligne */
 span.activity.expe{

--- a/collectives/static/css/event/event.css
+++ b/collectives/static/css/event/event.css
@@ -1,75 +1,36 @@
-#eventlist{
+#eventlist .row{
+    padding: 20px 20px;
+    display: flex;
+    flex-direction: row;
+}
+#eventlist .row .section{
+    margin: 0 20px;
 }
 
-#eventlist .action{
-  text-align: right;
-  padding: 0 40px;
+#eventlist #eventstable img.photo{
+    height: 130px;
+    width: 200px;
 }
-#eventlist .action input{
-  background-color: white;
-  box-sizing: border-box;
-  margin: 8px 0;
-  padding: 1em;
-  border: none;
-  font-size: 1em;
-
-  border-radius: 5px;
-  color: black;
-
-  cursor: pointer;
+#eventlist #eventstable h4{
+    font-size: 200%;
+    margin: 0;
 }
-
-
-#eventlist .event{
-  width: 47%;
-  margin: 1%;
-  height: 200px;
-  float: left;
-  border: 2px solid #666666;
-  background: rgba(255, 255, 255, 0.9);
-  overflow: hidden;
-  border-radius: 20px;
+#eventlist #eventstable .row div div{
+    font-size: 150%;
 }
-/* Mobile Adjustment :less event on same line*/
-@media only screen and (max-width:1000px) {
-	#eventlist .event{
-		width: 95%;
-	}
+#eventlist #eventstable .activities{
+    height: 130px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+#eventlist #eventstable .activity{
+    margin: 1px;
 }
 
-#eventlist .event .photo{
-  height: 200px;
-  width: 200px;
-  float: left;
-  object-fit: cover;
-  background: url("../img/icon/ionicon/md-images.svg");
-  background-color: white;
+#eventlist #eventstable .slots .free_slot{
+    opacity: .5;
 }
-
-#eventlist .event h3{
-  text-align: center;
-  background-color: #00a6d0;
-  margin: 0;
-  font-size: 2em;
-}
-#eventlist .event h3 img{
-  height: 1em;
-  position: relative;
-  top: .15em;
-}
-
-#eventlist .event h4{
-  text-align: right;
-  padding: 0 5  px;
-  margin: 0.1em;
-}
-#eventlist .icon, #eventdetail .icon{
-  height: 1.2em;
-  position: relative;
-  top: .2em;
-}
-
-
 
 /* Event details */
 #eventdetail h3{

--- a/collectives/static/css/event/event.css
+++ b/collectives/static/css/event/event.css
@@ -1,9 +1,21 @@
-#eventlist .row{
+#eventlist #filters{
+    background: white;
+    padding: 20px;
+    text-align: right;
+}
+#eventlist #filters .unselected{
+    opacity: .5;
+}
+#eventlist #filters .activity{
+    cursor: pointer;
+}
+
+#eventlist #eventstable .row{
     padding: 20px 20px;
     display: flex;
     flex-direction: row;
 }
-#eventlist .row .section{
+#eventlist #eventstable .row .section{
     margin: 0 20px;
 }
 

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -1,6 +1,6 @@
 
 var locale = window.navigator.userLanguage || window.navigator.language;
-var eventstable;
+var eventsTable;
 moment.locale(locale);
 String.prototype.capitalize = function() {
   return this.charAt(0).toUpperCase() + this.slice(1)
@@ -8,7 +8,7 @@ String.prototype.capitalize = function() {
 
 window.onload = function(){
 
-  		eventstable = new Tabulator("#eventstable", {
+  		eventsTable = new Tabulator("#eventstable", {
   			layout:"fitColumns",
   			ajaxURL: '/api/events/',
             ajaxSorting:true,
@@ -18,9 +18,9 @@ window.onload = function(){
             // Activate grouping only if we sort by start date
             dataSorting : function(sorters){
                 if(sorters[0]['field'] != 'title')
-                    eventstable.setGroupBy(sorters[0]['field']);
+                    eventsTable.setGroupBy(sorters[0]['field']);
                 else
-                    eventstable.setGroupBy(false);
+                    eventsTable.setGroupBy(false);
             },
 
             pagination : 'remote',
@@ -110,15 +110,20 @@ function displayLeader(user){
 
 
 function toggleActivity(activity_id, element){
-    filter={field:"activity_type", type:"=", value:activity_id};
+    filter={field:"activity_type", type:"=", value: activity_id};
 
     // Toggle filter
-    if (eventstable.getFilters().filter(function(i ){
-                                            return i['field'] == filter['field'] && i['value'] == filter['value'] ;
-                                        }).length!=0)
-        eventstable.removeFilter( [{field:"activity_type", type:"=", value:activity_id}]);
-    else
-        eventstable.addFilter( [{field:"activity_type", type:"=", value:activity_id}]);
+    currentActivityFilter=eventsTable.getFilters().filter(function(i ){ return i['field'] == "activity_type" });
+
+
+    if (currentActivityFilter.length ==0)
+        eventsTable.addFilter( [filter]);
+    else if (currentActivityFilter[0]['value'] == activity_id)
+        eventsTable.removeFilter(currentActivityFilter);
+    else{
+        eventsTable.removeFilter(currentActivityFilter);
+        eventsTable.addFilter( [filter]);
+    }
 
     refreshFilterDisplay();
 }
@@ -127,10 +132,10 @@ function togglePastActivities(element){
 
     if ( ! element.checked){
         var now = moment().format('YYYY-MM-DDTHH:mm:ss'); // As ISO 8601
-        eventstable.addFilter( [{field:"end", type:"=", value:  now  }]);
+        eventsTable.addFilter( [{field:"end", type:"=", value:  now  }]);
     }else{
-        endfilter=eventstable.getFilters().filter(function(i ){ return i['field'] == "end" });
-        eventstable.removeFilter(endfilter);
+        endfilter=eventsTable.getFilters().filter(function(i ){ return i['field'] == "end" });
+        eventsTable.removeFilter(endfilter);
     }
 
 }
@@ -141,7 +146,7 @@ function refreshFilterDisplay(){
         button.classList.add('unselected');
 
     // Select activity filter button which appears in tabulator filter
-    for (filter of eventstable.getFilters())
+    for (filter of eventsTable.getFilters())
         if (filter['field'] == 'activity_type')
             document.querySelector('#eventlist #filters .'+filter['value']).classList.remove('unselected');
 }

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -1,0 +1,94 @@
+
+var locale = window.navigator.userLanguage || window.navigator.language;
+moment.locale(locale);
+String.prototype.capitalize = function() {
+  return this.charAt(0).toUpperCase() + this.slice(1)
+}
+
+window.onload = function(){
+
+  		var eventstable = new Tabulator("#eventstable", {
+  			layout:"fitColumns",
+  			ajaxURL: '/api/events/',
+  			resizableColumns:false,
+            groupBy:"start",
+            pagination : 'remote',
+            paginationSize : 10,
+            //initialSort:[ {column:"start", dir:"asc"}],
+  			columns:[
+      			{title:"Titre", field:"title", sorter:"string"},
+                {title:"Date", field:"start", sorter:"string"},
+  			],
+            rowClick: function(e, row){ document.location= row.getData().view_uri},
+  			rowFormatter: eventRowFormatter,
+            groupHeader:function(value, count, data, group){
+                return moment(new Date(value)).format('dddd D MMMM YYYY').capitalize();
+            },
+  		})
+};
+
+function eventRowFormatter(row){
+    var element = row.getElement();
+    var data    = row.getData();
+    var width   = element.offsetWidth;
+    var html    = "";
+
+    //clear current row data
+    element.childNodes.forEach(function(e){ e.style.display="none"});
+
+    //define a table layout structure and set width of row
+    divRow = document.createElement("div");
+    divRow.className = "row tabulator-cell";
+    divRow.setAttribute("role","gridcell");
+    divRow.style.width = (width - 18) + "px";
+
+    //add row data on right hand side
+    html += `<div class="activities section">`;
+    for (const activity of data.activity_types)
+                html += `<span class="activity ${activity['short']} type"></span>`;
+    html += `</div>`;
+
+    html += `<div class="section">
+                <img src="${data.photo_uri}" class="photo"/>
+             </div>`;
+
+    html += `<div class="section">
+                 <h4>${data.title}</h4>
+                 <div class="date">
+                     <img src="/static/img/icon/ionicon/md-calendar.svg" class="icon"/>
+                     ${localInterval(data.start, data.end)}
+                 </div>
+
+                 <div class="leader">
+                    Par ${data.leaders.map(displayLeader).join('et')}
+                 </div>
+                 <div class="slots">
+                    ${slots(data.num_slots - data.free_slots)}
+                    ${slots(data.free_slots, 'free_slot')}
+                 </div>
+             </div>
+             <div class="breaker"></div>`;
+    divRow.innerHTML = html;
+
+    //append newly formatted contents to the row
+    element.append(divRow);
+}
+
+function localInterval(start, end){
+    if( start == end)
+        return localDate(new Date(start));
+    return `${localDate(new Date(start))} au ${localDate(new Date(end))}`;
+}
+
+function localDate(date){
+    return moment(date).format('ddd D MMM YY');
+}
+function slots(nb, css){
+    if(css == undefined)
+        css = '';
+    var slot = `<img src="/static/img/icon/ionicon/md-contact.svg" class="icon ${css}"/>`;
+    return (new Array(nb)).fill( slot ).join('');
+}
+function displayLeader(user){
+    return user.name;
+}

--- a/collectives/static/js/profile.js
+++ b/collectives/static/js/profile.js
@@ -1,0 +1,45 @@
+var locale = window.navigator.userLanguage || window.navigator.language;
+var eventstable;
+moment.locale(locale);
+
+window.onload = function(){
+    var common_options = {
+        layout:"fitDataFill",
+        ajaxURL: ajaxURL, // URL is defined in template
+
+        paginationSize : 10,
+        initialSort: [ {column:"start", dir:"asc"}],
+        initialFilter: [
+            {field:"end", type:">", value:  moment().format('YYYY-MM-DDTHH:mm:ss')  }
+        ],
+        columns:[
+            {title: "Type",         field:"activity_types", formatter: typesFormatter     },
+            {title: "Titre",        field:"title",          sorter:"string"                 },
+            {title: "Date",         field:"start",          sorter:"string",             formatter:"datetime",
+                    formatterParams:{   outputFormat:"dddd D MMMM YYYY", invalidPlaceholder:"(invalid date)",}  },
+            {title: "Participants", field: "occupied_slots" },
+            {title: "Encadrant",    field:"leaders",        formatter: leadersFormatter     }
+        ],
+        rowClick: function(e, row){ document.location= row.getData().view_uri},
+    };
+
+
+    var eventstable= new Tabulator("#eventstable",
+                    Object.assign(common_options, {   initialFilter: [
+                                {field:"end", type:">", value:  moment().format('YYYY-MM-DDTHH:mm:ss')  }
+                            ]}));
+    var pasteventstable= new Tabulator("#pasteventstable",
+                    Object.assign(common_options, {   initialFilter: [
+                                {field:"end", type:"<", value:  moment().format('YYYY-MM-DDTHH:mm:ss')  }
+                            ]}));
+}
+
+function leadersFormatter(cell, formatterParams, onRendered){
+    var names = cell.getValue().map((leader) => leader['name']);
+    return names.join('<br/>');
+}
+
+function typesFormatter(cell, formatterParams, onRendered){
+    var names = cell.getValue().map((activity) => `<span class="activity ${activity['short']} s30px"></span>`);
+    return names.join(' ');
+}

--- a/collectives/templates/index.html
+++ b/collectives/templates/index.html
@@ -8,15 +8,22 @@
 {% endblock %}
 
 {% block additionalhead %}
+
+
+  {# Tabulator: for tables#}
+  <link href="https://unpkg.com/tabulator-tables@4.5.1/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
+
+  
   <link rel="stylesheet" href="{{ url_for('static', filename='css/event/event.css') }}">
+  <script src="{{ url_for('static', filename='js/event/eventlist.js') }}"></script>
 {% endblock %}
 
 {% block content %}
 
 <div id="eventlist" class="panel">
-{% for event in events %}
-  {{ macros.eventitem(event) }}
-{% endfor %}
+    <div id="eventstable"></div>
 </div>
 
 {% endblock %}

--- a/collectives/templates/index.html
+++ b/collectives/templates/index.html
@@ -25,7 +25,7 @@
 <div id="eventlist" class="panel">
     <div id="filters">
         <div class="">
-            <label>Evènements passées: <input
+            <label>Evènements passés: <input
                                             type="checkbox"
                                             onchange="togglePastActivities(this)"
                                             autocomplete="off"

--- a/collectives/templates/index.html
+++ b/collectives/templates/index.html
@@ -15,7 +15,7 @@
   <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.js"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
 
-  
+
   <link rel="stylesheet" href="{{ url_for('static', filename='css/event/event.css') }}">
   <script src="{{ url_for('static', filename='js/event/eventlist.js') }}"></script>
 {% endblock %}
@@ -23,6 +23,24 @@
 {% block content %}
 
 <div id="eventlist" class="panel">
+    <div id="filters">
+        <div class="">
+            <label>Evènements passées: <input
+                                            type="checkbox"
+                                            onchange="togglePastActivities(this)"
+                                            autocomplete="off"
+                                            /></label>
+        </div>
+        <div class="activity_filters">
+            Activité:
+            {% for type in types %}
+                <span
+                    class="activity {{type.short}} unselected s30px"
+                    onclick="toggleActivity('{{type.short}}');"
+                ></span>
+            {% endfor %}
+        </div>
+    </div>
     <div id="eventstable"></div>
 </div>
 

--- a/collectives/templates/leader_profile.html
+++ b/collectives/templates/leader_profile.html
@@ -3,8 +3,16 @@
 {% import 'macros.html' as macros with context %}
 
 {% block additionalhead %}
-  <script src="{{ url_for('static', filename='js/index.js') }}"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/event/event.css') }}">
+
+  <link href="https://unpkg.com/tabulator-tables@4.5.1/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
+
+  <script>
+      var ajaxURL= '/api/leader/{{user.id}}/events';
+  </script>
+  <script src="{{ url_for('static', filename='js/profile.js') }}"></script>
 {% endblock %}
 
 {% block header %}
@@ -33,21 +41,11 @@
     </ul>
 
     <h4>Sorties encadrées à venir</h4>
-    <div id="eventlist" class="panel" style="display:inline">
-        {% for event in next_events %}
-            {{ macros.eventitem(event) }}
-        {% else %}
-            Aucune sortie à venir
-        {% endfor %}
+    <div id="eventstable">
     </div>
 
     <h4>Sorties encadrées effectuées</h4>
-    <div id="eventlist" class="panel" style="display:inline">
-        {% for event in past_events %}
-            {{ macros.eventitem(event) }}
-        {% else %}
-            Aucune sortie encadrée jusqu'à présent
-        {% endfor %}
+    <div id="pasteventstable">
     </div>
 </div>
 

--- a/collectives/templates/profile.html
+++ b/collectives/templates/profile.html
@@ -3,8 +3,16 @@
 {% import 'macros.html' as macros with context %}
 
 {% block additionalhead %}
-  <script src="{{ url_for('static', filename='js/index.js') }}"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/event/event.css') }}">
+
+  <link href="https://unpkg.com/tabulator-tables@4.5.1/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
+  <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
+
+  <script>
+      var ajaxURL= '/api/user/{{user.id}}/events';
+  </script>
+  <script src="{{ url_for('static', filename='js/profile.js') }}"></script>
 {% endblock %}
 
 {% block header %}
@@ -27,21 +35,11 @@
     {% endif %}
 
     <h4>Sorties à venir</h4>
-    <div id="eventlist" class="panel" style="display:inline">
-        {% for event in next_events %}
-            {{ macros.eventitem(event[1]) }}
-        {% else %}
-            <li>Aucune sortie à venir</li>
-        {% endfor %}
+    <div id="eventstable">
     </div>
 
     <h4>Sorties effectuées</h4>
-    <div id="eventlist" class="panel" style="display:inline">
-        {% for event in past_events %}
-            {{ macros.eventitem(event[1]) }}
-        {% else %}
-            <li>Aucune sortie encadrée jusqu'à présent</li>
-        {% endfor %}
+    <div id="pasteventstable">
     </div>
 </div>
 


### PR DESCRIPTION
A first step into a different event list page. Using tabulator adds us a great deal of standard function (infinite scroll, pagination, filtering, sorting, grouping, etc...). Plus it uses the api.

In this PR, I have:
- integrated tabulator,
- added pagination, https://trello.com/c/b7TE87Qn/14-paginer-la-liste-des-collectives
- grouped event by start date
- displayed leader name into list https://trello.com/c/pMW1Cmvg/103-liste-des-collectives-afficher-le-nom-de-lencadrant

In next PR:
- a better design around tabulator
- integrate filtering and sorting by activity or date https://trello.com/c/lbbvhrSs/25-pouvoir-trier-et-filtrer-la-liste-de-collectives
