### PR TITLE
Use app timezone rather than client for time comparisons

### DIFF
--- a/collectives/context_processor.py
+++ b/collectives/context_processor.py
@@ -1,4 +1,5 @@
 # Helpers functions that are make available to Jinja
+from .helpers import current_time
 
 # Server may not have fr_FR locale installed, for convenience
 # simply define days of weeks and months names here
@@ -38,6 +39,10 @@ def helpers_processor():
         return 'du {} au {}'.format(
             format_date_short(start), format_date_short(end))
 
+    def server_local_time():
+        return current_time()
+
     return dict(format_date=format_date, format_time=format_time,
                 format_date_range=format_date_range,
-                format_datetime_range=format_datetime_range)
+                format_datetime_range=format_datetime_range,
+                server_local_time=server_local_time)

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -131,8 +131,7 @@ function toggleActivity(activity_id, element){
 function togglePastActivities(element){
 
     if ( ! element.checked){
-        var now = moment().format('YYYY-MM-DDTHH:mm:ss'); // As ISO 8601
-        eventsTable.addFilter( [{field:"end", type:"=", value:  now  }]);
+        eventsTable.addFilter( [{field:"end", type:"=", value:getServerLocalTime() }]);
     }else{
         endfilter=eventsTable.getFilters().filter(function(i ){ return i['field'] == "end" });
         eventsTable.removeFilter(endfilter);

--- a/collectives/static/js/profile.js
+++ b/collectives/static/js/profile.js
@@ -10,7 +10,7 @@ window.onload = function(){
         paginationSize : 10,
         initialSort: [ {column:"start", dir:"asc"}],
         initialFilter: [
-            {field:"end", type:">", value:  moment().format('YYYY-MM-DDTHH:mm:ss')  }
+            {field:"end", type:">", value:  getServerLocalTime()}
         ],
         columns:[
             {title: "Type",         field:"activity_types", formatter: typesFormatter     },
@@ -26,11 +26,11 @@ window.onload = function(){
 
     var eventstable= new Tabulator("#eventstable",
                     Object.assign(common_options, {   initialFilter: [
-                                {field:"end", type:">", value:  moment().format('YYYY-MM-DDTHH:mm:ss')  }
+                                {field:"end", type:">", value:getServerLocalTime() }
                             ]}));
     var pasteventstable= new Tabulator("#pasteventstable",
                     Object.assign(common_options, {   initialFilter: [
-                                {field:"end", type:"<", value:  moment().format('YYYY-MM-DDTHH:mm:ss')  }
+                                {field:"end", type:"<", value:getServerLocalTime()  }
                             ]}));
 }
 

--- a/collectives/templates/base.html
+++ b/collectives/templates/base.html
@@ -4,6 +4,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='caf/icon/activity.css') }}">
     <link rel="icon" href="{{ url_for('static', filename=conf['FAVICON']) }}" />
+    <script type="text/javascript">function getServerLocalTime(){ return '{{server_local_time()}}'; }</script>
     {% block additionalhead %}{% endblock %}
 </head>
 <body>

--- a/collectives/templates/index.html
+++ b/collectives/templates/index.html
@@ -13,8 +13,8 @@
   {# Tabulator: for tables#}
   <link href="https://unpkg.com/tabulator-tables@4.5.1/dist/css/materialize/tabulator_materialize.min.css" rel="stylesheet">
   <script type="text/javascript" src="https://unpkg.com/tabulator-tables@4.5.1/dist/js/tabulator.js"></script>
+ 
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
-
 
   <link rel="stylesheet" href="{{ url_for('static', filename='css/event/event.css') }}">
   <script src="{{ url_for('static', filename='js/event/eventlist.js') }}"></script>


### PR DESCRIPTION
Utilise l'heure serveur plutot que moment.js pour les comparaisons de date (utile si le browser est dans une autre timezone, ce qui est fréquemment mon cas par exemple)