### PR TITLE
Fix/52

### DIFF
--- a/collectives/event.py
+++ b/collectives/event.py
@@ -110,17 +110,18 @@ def manage_event(event_id=None):
     if not event.starts_before_ends():
         flash('La date de début doit être antérieure à la date de fin')
         valid = False
-    if not event.opens_before_closes():
-        flash('Les inscriptions internet doivent ouvrir avant de terminer')
-        valid = False
-    if not event.opens_before_ends():
-        flash('Les inscriptions internet doivent ouvrir avant la fin de l\'événement')
-        valid = False
-    if event.num_slots < event.num_online_slots:
-        flash('Le nombre de places internet ne doit pas dépasser le nombre de places total')
-        valid = False
-    if event.num_online_slots < 0:
-        flash('Le nombre de places ne peut être négatif')
+    if event.num_online_slots > 0:
+        if not event.opens_before_closes():
+            flash('Les inscriptions internet doivent ouvrir avant de terminer')
+            valid = False
+        if not event.opens_before_ends():
+            flash('Les inscriptions internet doivent ouvrir avant la fin de l\'événement')
+            valid = False
+        if event.num_slots < event.num_online_slots:
+            flash('Le nombre de places internet ne doit pas dépasser le nombre de places total')
+            valid = False
+    elif event.num_online_slots < 0:
+        flash('Le nombre de places par internet ne peut être négatif')
         valid = False
 
     if not valid:

--- a/collectives/event.py
+++ b/collectives/event.py
@@ -111,12 +111,16 @@ def manage_event(event_id=None):
         flash('La date de début doit être antérieure à la date de fin')
         valid = False
     if event.num_online_slots > 0:
-        if not event.opens_before_closes():
-            flash('Les inscriptions internet doivent ouvrir avant de terminer')
+        if not event.has_defined_registration_date():
+            flash("Les date de début ou fin d\'ouverture ou de fermeture d'inscription ne peuvent être nulles.")
             valid = False
-        if not event.opens_before_ends():
-            flash('Les inscriptions internet doivent ouvrir avant la fin de l\'événement')
-            valid = False
+        else:
+            if not event.opens_before_closes():
+                flash('Les inscriptions internet doivent ouvrir avant de terminer')
+                valid = False
+            if not event.opens_before_ends():
+                flash('Les inscriptions internet doivent ouvrir avant la fin de l\'événement')
+                valid = False
         if event.num_slots < event.num_online_slots:
             flash('Le nombre de places internet ne doit pas dépasser le nombre de places total')
             valid = False

--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -112,6 +112,12 @@ class Event(db.Model):
         return self.rendered_description
 
     # Date validation
+    def has_defined_registration_date(self):
+        # One should not creat an event with online slot defined but
+        # any registration dates (open and close)
+        if not self.registration_open_time or not self.registration_close_time:
+            return False
+        return  True
 
     def starts_before_ends(self):
         # Event must starts before it ends
@@ -151,7 +157,8 @@ class Event(db.Model):
                    self.has_valid_slots() and
                    self.has_valid_leaders() and
                    self.starts_before_ends() and
-                   self.opens_before_closes())
+                   self.opens_before_closes() and
+                   self.has_defined_registration_date())
 
     def is_leader(self, user):
         return user in self.leaders

--- a/migrations/versions/c7fe6453ad90_drop_constraint_nullable_in_events_.py
+++ b/migrations/versions/c7fe6453ad90_drop_constraint_nullable_in_events_.py
@@ -1,0 +1,32 @@
+"""Drop constraint nullable in events.registration_open_time
+
+Revision ID: c7fe6453ad90
+Revises: afe864919723
+Create Date: 2020-01-07 17:54:46.105665
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from collectives.models import db
+
+
+# revision identifiers, used by Alembic.
+revision = 'c7fe6453ad90'
+down_revision = 'afe864919723'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Change events.registration_open_time 'nullable' False to True
+    with op.batch_alter_table('events') as batch_op:
+        batch_op.alter_column('registration_open_time', nullable=True)
+        batch_op.alter_column('registration_close_time', nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table('events') as batch_op:
+        batch_op.alter_column('registration_open_time', nullable=False)
+        batch_op.alter_column('registration_close_time', nullable=False)
+    pass

--- a/tests.py
+++ b/tests.py
@@ -120,12 +120,9 @@ class TestEvents(TestUsers):
         return Event(title="Event",
                      description="",
                      shortdescription="",
-                     num_slots=2, num_online_slots=1,
+                     num_slots=2, num_online_slots=0,
                      start=datetime.datetime.now() + datetime.timedelta(days=1),
-                     end=datetime.datetime.now() + datetime.timedelta(days=2),
-                     registration_open_time=datetime.datetime.now(),
-                     registration_close_time=datetime.datetime.now() +
-                     datetime.timedelta(days=1))
+                     end=datetime.datetime.now() + datetime.timedelta(days=2))
 
     def test_add_event(self):
         event = self.make_event()
@@ -164,6 +161,7 @@ class TestEvents(TestUsers):
 
         # Test slots
         event.num_slots = 0
+        event.num_online_slots = 1
         assert not event.is_valid()
         event.num_online_slots = 0
         assert event.is_valid()
@@ -177,6 +175,11 @@ class TestEvents(TestUsers):
         assert not event.is_valid()
         event.end = event.start
         assert event.is_valid()
+
+        event.num_online_slots = 1
+        event.registration_open_time = datetime.datetime.now()
+        event.registration_close_time = datetime.datetime.now() + \
+            datetime.timedelta(days=1)
 
         assert event.is_registration_open_at_time(datetime.datetime.now())
 
@@ -209,6 +212,10 @@ class TestRegistrations(TestEvents):
     def test_add_registration(self):
         event = self.make_event()
         event.num_online_slots = 2
+        event.registration_open_time = datetime.datetime.now()
+        event.registration_close_time = datetime.datetime.now() + \
+            datetime.timedelta(days=1)
+
         db.session.add(event)
         db.session.commit()
 


### PR DESCRIPTION
Ce coup ci c'est prêt pour test ou relecture.

J'aimerai bien ajouter la valeur par défaut « 0 » au champ online_slots mais ça fait assez longtemps que je suis sur ce correctif… Si vous voyez en 3 min comment l'ajouter.. « default=0 » n'a pas l'air de suffir dans le modèle de la table events.
Oui ça peut se faire par js mais bof.