### PR TITLE
Add explicit extranet sync button

### DIFF
--- a/collectives/templates/profile.html
+++ b/collectives/templates/profile.html
@@ -22,23 +22,34 @@
 {% block content %}
 <div class="panel" id="eventdetail">
     <h3>{{user.full_name()}}</h3>
-
-    {% if user.license_expiry_date %}
-    <p>
-        Licence de catégorie {{user.license_category}} expirant le {{format_date(user.license_expiry_date)}}.
-    </p>
+    
+    {% if user == current_user %}
+    <a class="button" href="{{url_for('root.update_user')}}">Modifier mes paramètres</a>
+    {% elif current_user.is_admin() %}
+    <a class="button" href="{{url_for('administration.manage_user', user_id=user.id)}}">Modifier l'utilisateur</a>
     {% endif %}
 
-    <h4>Informations de contact</h4>
+
+    <h4>Informations FFCAM </h4>
     <ul>
+        {% if user.license_expiry_date %}
+        <li>
+            Licence de catégorie {{user.license_category}} expirant le {{format_date(user.license_expiry_date)}}.
+        </li>
+        {% endif %}
         <li><b>Email :</b> {{user.mail}}</li>
         <li><b>Téléphone :</b> {{user.phone}}</li>
         <li><b>En cas d'accident :</b> {{user.emergency_contact_name}} au {{user.emergency_contact_phone}}</li>
     </ul>
+    
     {% if user == current_user %}
-    <a class="button" href="{{url_for('root.update_user')}}">Modifier mes informations</a>
-    {% elif current_user.is_admin() %}
-    <a class="button" href="{{url_for('administration.manage_user', user_id=user.id)}}">Modifier l'utilisateur</a>
+    <form action="{{url_for('root.force_user_sync')}}" method="post"> 
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <input type="submit" value="Resynchronizer mes informations FFCAM">
+        <p class="contact-link">
+            Si après synchronization ces informations ne sont toujours pas à jour, veuillez contacter <a href="mailto:secretariat@cafannecy.fr">le secrétariat du club.</a>
+        </p>
+    </form>
     {% endif %}
 
     <h4>Sorties à venir</h4>

--- a/collectives/views.py
+++ b/collectives/views.py
@@ -9,6 +9,7 @@ import os
 from .forms import UserForm
 from .models import User, Registration, RegistrationStatus, Event, db
 from .helpers import current_time
+from .auth import sync_user
 
 images = Images()
 
@@ -88,3 +89,11 @@ def update_user():
     db.session.commit()
 
     return redirect(url_for('root.update_user'))
+
+@root.route('/user/force_sync', methods=['POST'])
+@login_required
+def force_user_sync():
+    sync_user(current_user, True)
+    return redirect(url_for('root.show_user', user_id=current_user.id))
+
+


### PR DESCRIPTION
https://trello.com/c/ToVw6f0r/128-profil-utilisateur-ne-pas-rendre-modifiable-les-donn%C3%A9es-venant-de-lextranet

Mettre à dispo un bouton sur le profil utilisateur permettant de resynchroniser les données suite au changement côté extranet