### PR TITLE
Event: remove short description

### DIFF
--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -70,6 +70,7 @@ class Event(db.Model):
     title = db.Column(db.String(100), nullable=False)
     description = db.Column(db.Text(), nullable=False, default='')
     rendered_description = db.Column(db.Text(), nullable=True, default='')
+    # TODO: remove the column when sqlite won't be used
     shortdescription = db.Column(db.String(100), nullable=True, default='')
     photo = db.Column(db.String(100), nullable=True)
     start = db.Column(db.DateTime, nullable=False, index=True)

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -34,7 +34,6 @@
      <label for="type">Type : </label> {{ form.type }}<br/>
      <label for="status">État : </label> {{ form.status }}<br/>
      <label for="num_slots">Nombre de participants : </label> {{ form.num_slots(size=4) }}<br/>
-     <label for="shortdescription">Dénivelé, difficulté, cotation : </label> {{ form.shortdescription(size=99) }}<br/>
 
     <div class="dates">
       <h4>Dates</h4>

--- a/tests.py
+++ b/tests.py
@@ -132,7 +132,6 @@ class TestEvents(TestUsers):
     def make_event(self):
         return Event(title="Event",
                      description="",
-                     shortdescription="",
                      num_slots=2, num_online_slots=0,
                      start=datetime.datetime.now() + datetime.timedelta(days=1),
                      end=datetime.datetime.now() + datetime.timedelta(days=2))


### PR DESCRIPTION
J'ai conservé le champ, car il est chiant à enlevé dans sqlite. Mais ca sera à faire plus tard.
https://trello.com/c/yXuK7Vj4/107-supprimer-le-champ-d%C3%A9nivel%C3%A9-difficult%C3%A9-cotation