### PR TITLE
Markdown editor

### DIFF
--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -2,8 +2,8 @@
 
 from flask import current_app
 from flask_uploads import UploadSet, IMAGES
-from delta import html
-import json
+import markdown
+import enum
 import re
 
 from . import db
@@ -110,7 +110,11 @@ class Event(db.Model):
             self.photo = filename
 
     def set_rendered_description(self, description):
-        self.rendered_description = html.render(json.loads(description)['ops'])
+        # Urify links
+        # From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
+        URI_REGEX = r'(?i)(^|^\s|[^(]\s+)((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
+        description = re.sub(URI_REGEX, r'\1[\2](\2)', description)
+        self.rendered_description = markdown.markdown(description, extensions=['nl2br'])
         return self.rendered_description
 
     # Date validation

--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -3,7 +3,6 @@
 from flask import current_app
 from flask_uploads import UploadSet, IMAGES
 import markdown
-import enum
 import re
 
 from . import db

--- a/collectives/models/event.py
+++ b/collectives/models/event.py
@@ -112,7 +112,7 @@ class Event(db.Model):
     def set_rendered_description(self, description):
         # Urify links
         # From https://daringfireball.net/2010/07/improved_regex_for_matching_urls
-        URI_REGEX = r'(?i)(^|^\s|[^(]\s+)((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
+        URI_REGEX = r'(?i)(^|^\s|[^(]\s+|[^\]]\(\s*)((?:[a-z][\w-]+:(?:/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:\'".,<>?«»“”‘’]))'
         description = re.sub(URI_REGEX, r'\1[\2](\2)', description)
         self.rendered_description = markdown.markdown(description, extensions=['nl2br'])
         return self.rendered_description

--- a/collectives/routes/event.py
+++ b/collectives/routes/event.py
@@ -12,7 +12,7 @@ from ..email_templates import send_new_event_notification
 from ..email_templates import send_unregister_notification
 
 from ..helpers import current_time, slugify
-from ..utils.export import to_xlsx, strip_tags
+from ..utils.export import to_xlsx 
 from ..utils.csv import process_stream
 
 blueprint = Blueprint('event', __name__, url_prefix='/event')
@@ -94,7 +94,7 @@ def print_event(event_id):
         return redirect(url_for('event.index'))
 
     activity_names = [at.name for at in event.activity_types]    
-    description = escape(strip_tags(event.description))
+    description = escape(event.description)
     return render_template('print_event.html',
                             event = event,
                             description = description,

--- a/collectives/static/css/administration.css
+++ b/collectives/static/css/administration.css
@@ -41,11 +41,19 @@
   font-size:80%;
 }
 
-#administration #editor, #administration .ql-toolbar{
+#administration #editor{
   width: 80%;
   margin:auto;
+	text-align: left;
 }
 
-#administration #editor{
+#administration #description{
   height: 20em;
+}
+
+#editor a{
+  text-decoration: underline;
+}
+#editor a:hover{
+  text-decoration: none;
 }

--- a/collectives/static/css/event/edit.css
+++ b/collectives/static/css/event/edit.css
@@ -23,8 +23,16 @@
 #eventedit #editor, #eventedit .ql-toolbar{
   width: 80%;
   margin:auto;
+	text-align: left;
 }
 
-#eventedit #editor{
+#eventedit #editor-area{
   height: 40em;
+}
+
+#editor a{
+  text-decoration: underline;
+}
+#editor a:hover{
+  text-decoration: none;
 }

--- a/collectives/static/css/event/edit.css
+++ b/collectives/static/css/event/edit.css
@@ -20,13 +20,13 @@
 }
 
 
-#eventedit #editor, #eventedit .ql-toolbar{
+#eventedit #editor {
   width: 80%;
   margin:auto;
 	text-align: left;
 }
 
-#eventedit #editor-area{
+#eventedit #description{
   height: 40em;
 }
 

--- a/collectives/static/css/event/edit.css
+++ b/collectives/static/css/event/edit.css
@@ -22,7 +22,7 @@
 
 #eventedit #editor {
   width: 80%;
-  margin:auto;
+  margin: 1em auto;
 	text-align: left;
 }
 

--- a/collectives/static/css/event/event.css
+++ b/collectives/static/css/event/event.css
@@ -154,3 +154,10 @@ span.event-status{
   color:white;
   background-color:  rgb(60, 60, 60);
 }
+
+#description a{
+  text-decoration: underline;
+}
+#description a:hover{
+  text-decoration: none;
+}

--- a/collectives/static/js/event/edit.js
+++ b/collectives/static/js/event/edit.js
@@ -1,6 +1,112 @@
 // Fonction to copy start date into end date in case of one day event
-function copyStartDate(){
+function copyStartDate() {
     if (!document.querySelector('input[name=end]').value)
         document.querySelector('input[name=end]').value = document.querySelector('input[name=start]').value;
 }
 
+function makeEditorToolbar() {
+    return [
+        {
+            name: "bold",
+            action: SimpleMDE.toggleBold,
+            className: "fa fa-bold",
+            title: "Gras",
+        },
+        {
+            name: "italic",
+            action: SimpleMDE.toggleItalic,
+            className: "fa fa-italic",
+            title: "Italique",
+        },
+        {
+            name: "strikethrough",
+            action: SimpleMDE.toggleStrikethrough,
+            className: "fa fa-strikethrough",
+            title: "Barré",
+        },
+        {
+            name: "heading",
+            action: SimpleMDE.toggleHeadingSmaller,
+            className: "fa fa-header",
+            title: "Titre",
+        },
+        "|",
+        {
+            name: "list-ul",
+            action: SimpleMDE.toggleUnorderedList,
+            className: "fa fa-list-ul",
+            title: "Liste",
+        },
+        {
+            name: "list-ol",
+            action: SimpleMDE.toggleOrderedList,
+            className: "fa fa-list-ol",
+            title: "Liste numérotée",
+        },
+        "|",
+        {
+            name: "link",
+            action: SimpleMDE.drawLink,
+            className: "fa fa-link",
+            title: "Lien hypertexte",
+        },
+        {
+            name: "image",
+            action: SimpleMDE.drawImage,
+            className: "fa fa-picture-o",
+            title: "Image",
+        },
+        {
+            name: "table",
+            action: SimpleMDE.drawTable,
+            className: "fa fa-table",
+            title: "Tableau",
+        },
+        "|",
+        {
+            name: "preview",
+            action: SimpleMDE.togglePreview,
+            className: "fa fa-eye no-disable",
+            title: "Aperçu",
+        },
+        {
+            name: "side-by-side",
+            action: SimpleMDE.toggleSideBySide,
+            className: "fa fa-columns no-disable no-mobile",
+            title: "Aperçu temps-réel",
+        },
+        {
+            name: "fullscreen",
+            action: SimpleMDE.toggleFullScreen,
+            className: "fa fa-arrows-alt no-disable no-mobile",
+            title: "Plein écran",
+        },
+        "|",
+        {
+            name: "guide",
+            action: "https://docs.framasoft.org/fr/mattermost/help/messaging/formatting-text.html",
+            className: "fa fa-question-circle",
+            title: "Aide",
+        },
+
+    ]
+
+}
+
+function getEditorOptions(elementId) {
+    return {
+        element: document.getElementById(elementId),
+        blockStyles: { italic: "_" },
+        spellChecker: false,
+        status: false,
+        promptURLs: true,
+        toolbar: makeEditorToolbar()
+    };
+}
+
+function makeEditor(elementId)
+{
+    var simplemde = new SimpleMDE(getEditorOptions(elementId));
+    simplemde.options.promptTexts = { "link": "Adresse du lien", "image": "Adresse de l'image" };
+    return simplemde;
+}

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -49,8 +49,9 @@
     </div>
 
     <h4>Description</h4>
-    <div id="editor"><textarea id="editor-area"></textarea></div>
-    {{ form.description(style="display:none;", required=false) }}<br/>
+    <div id="editor">
+    {{ form.description }}
+    </div>
     <label for="photo_file">Image de présentation : <br/>&#9432; Max 2MB. Photo uniquement </label> {{ form.photo_file }} <br/>
     <br/>
     {{ form.hidden_tag() }}
@@ -62,100 +63,7 @@ tail.DateTime("input[type=datetime]",{
     weekStart: 1
 });
 
-var simplemde = new SimpleMDE({ 
-  element: document.getElementById("editor-area"),
-  blockStyles: {italic:"_"},
-  spellChecker:false,
-  status:false,
-  promptURLs:true,
-  toolbar: [
-    {
-			name: "bold",
-			action: SimpleMDE.toggleBold,
-			className: "fa fa-bold",
-			title: "Gras",
-		},
-    {
-			name: "italic",
-			action: SimpleMDE.toggleItalic,
-			className: "fa fa-italic",
-			title: "Italique",
-		},
-    {
-			name: "strikethrough",
-			action: SimpleMDE.toggleStrikethrough,
-			className: "fa fa-strikethrough",
-			title: "Barré",
-		},
-    {
-			name: "heading",
-			action: SimpleMDE.toggleHeadingSmaller,
-			className: "fa fa-header",
-			title: "Titre",
-		},
-    "|",
-    {
-			name: "list-ul",
-			action: SimpleMDE.toggleUnorderedList,
-			className: "fa fa-list-ul",
-			title: "Liste",
-		},
-    {
-			name: "list-ol",
-			action: SimpleMDE.toggleOrderedList,
-			className: "fa fa-list-ol",
-			title: "Liste numérotée",
-		},
-    "|",
-    {
-			name: "link",
-			action: SimpleMDE.drawLink,
-			className: "fa fa-link",
-			title: "Lien hypertexte",
-		},
-    {
-			name: "image",
-			action: SimpleMDE.drawImage,
-			className: "fa fa-picture-o",
-			title: "Image",
-		},
-    {
-			name: "table",
-			action: SimpleMDE.drawTable,
-			className: "fa fa-table",
-			title: "Tableau",
-		},
-    "|",
-    {
-			name: "preview",
-			action: SimpleMDE.togglePreview,
-			className: "fa fa-eye no-disable",
-			title: "Aperçu",
-		},
-    {
-			name: "side-by-side",
-			action: SimpleMDE.toggleSideBySide,
-			className: "fa fa-columns no-disable no-mobile",
-			title: "Aperçu temps-réel",
-		},
-    {
-			name: "fullscreen",
-			action: SimpleMDE.toggleFullScreen,
-			className: "fa fa-arrows-alt no-disable no-mobile",
-			title: "Plein écran",
-		},
-    "|",
-    {
-			name: "guide",
-			action: "https://docs.framasoft.org/fr/mattermost/help/messaging/formatting-text.html",
-			className: "fa fa-question-circle",
-			title: "Aide",
-		},
-
-    ]
-   });
-simplemde.options.promptTexts = {"link" : "Adresse du lien", "image" : "Adresse de l'image"};
-simplemde.value(document.querySelector('textarea[name=description]').defaultValue);
+var simplemde = makeEditor("description");
 </script>
 
 {% endblock %}

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -11,8 +11,8 @@
   <script src="{{ url_for('static', filename='js/tail.datetime-full.min.js') }}"></script>
 
   {# Wysiwyg Editor #}
-  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+  <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
 {% endblock %}
 
 {% block header %}
@@ -26,7 +26,7 @@
   <form
         action="{{ action }}"
         method="POST"
-        onsubmit="document.querySelector('textarea[name=description]').value= JSON.stringify(quill.getContents())"
+        onsubmit="document.querySelector('textarea[name=description]').value=simplemde.value()"
         enctype="multipart/form-data"
   >
     <h4>Informations</h4>
@@ -49,7 +49,7 @@
     </div>
 
     <h4>Description</h4>
-    <div id="editor"></div>
+    <div id="editor"><textarea id="editor-area"></textarea></div>
     {{ form.description(style="display:none;", required=false) }}<br/>
     <label for="photo_file">Image de présentation : <br/>&#9432; Max 2MB. Photo uniquement </label> {{ form.photo_file }} <br/>
     <br/>
@@ -61,11 +61,101 @@
 tail.DateTime("input[type=datetime]",{
     weekStart: 1
 });
-var quill = new Quill('#editor', {
-  theme: 'snow'
-});
 
-quill.setContents(JSON.parse(document.querySelector('textarea[name=description]').defaultValue));
+var simplemde = new SimpleMDE({ 
+  element: document.getElementById("editor-area"),
+  blockStyles: {italic:"_"},
+  spellChecker:false,
+  status:false,
+  promptURLs:true,
+  toolbar: [
+    {
+			name: "bold",
+			action: SimpleMDE.toggleBold,
+			className: "fa fa-bold",
+			title: "Gras",
+		},
+    {
+			name: "italic",
+			action: SimpleMDE.toggleItalic,
+			className: "fa fa-italic",
+			title: "Italique",
+		},
+    {
+			name: "strikethrough",
+			action: SimpleMDE.toggleStrikethrough,
+			className: "fa fa-strikethrough",
+			title: "Barré",
+		},
+    {
+			name: "heading",
+			action: SimpleMDE.toggleHeadingSmaller,
+			className: "fa fa-header",
+			title: "Titre",
+		},
+    "|",
+    {
+			name: "list-ul",
+			action: SimpleMDE.toggleUnorderedList,
+			className: "fa fa-list-ul",
+			title: "Liste",
+		},
+    {
+			name: "list-ol",
+			action: SimpleMDE.toggleOrderedList,
+			className: "fa fa-list-ol",
+			title: "Liste numérotée",
+		},
+    "|",
+    {
+			name: "link",
+			action: SimpleMDE.drawLink,
+			className: "fa fa-link",
+			title: "Lien hypertexte",
+		},
+    {
+			name: "image",
+			action: SimpleMDE.drawImage,
+			className: "fa fa-picture-o",
+			title: "Image",
+		},
+    {
+			name: "table",
+			action: SimpleMDE.drawTable,
+			className: "fa fa-table",
+			title: "Tableau",
+		},
+    "|",
+    {
+			name: "preview",
+			action: SimpleMDE.togglePreview,
+			className: "fa fa-eye no-disable",
+			title: "Aperçu",
+		},
+    {
+			name: "side-by-side",
+			action: SimpleMDE.toggleSideBySide,
+			className: "fa fa-columns no-disable no-mobile",
+			title: "Aperçu temps-réel",
+		},
+    {
+			name: "fullscreen",
+			action: SimpleMDE.toggleFullScreen,
+			className: "fa fa-arrows-alt no-disable no-mobile",
+			title: "Plein écran",
+		},
+    "|",
+    {
+			name: "guide",
+			action: "https://docs.framasoft.org/fr/mattermost/help/messaging/formatting-text.html",
+			className: "fa fa-question-circle",
+			title: "Aide",
+		},
+
+    ]
+   });
+simplemde.options.promptTexts = {"link" : "Adresse du lien", "image" : "Adresse de l'image"};
+simplemde.value(document.querySelector('textarea[name=description]').defaultValue);
 </script>
 
 {% endblock %}

--- a/collectives/templates/import_csv.html
+++ b/collectives/templates/import_csv.html
@@ -2,10 +2,11 @@
 {% extends 'base.html' %}
 
 {% block additionalhead %}
+  <script src="{{ url_for('static', filename='js/event/edit.js') }}"></script>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/administration.css') }}">
   {# Wysiwyg Editor #}
-  <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-  <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+  <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
 {% endblock %}
 
 {% block header %}
@@ -42,19 +43,16 @@
     <p>
     Les marqueurs de type <em>$nom_de_colonne$</em> seront remplacés par la valeur de la colonne du même nom.
     </p>
-    <div id="editor"></div>
-    {{ form.description(style="display:none;", required=false) }}<br/>
-
+    <div id="editor">
+    {{ form.description }}
+    </div>
     <br/>
     {{ form.hidden_tag() }}
      <br/><input type="submit" value="Enregistrer"  />
   </form>
 </div>
 <script>
-var quill = new Quill('#editor', {
-  theme: 'snow'
-});
-quill.setContents(JSON.parse(document.querySelector('textarea[name=description]').defaultValue));
+var simplemde = makeEditor("description");
 </script>
 
 {% endblock %}

--- a/collectives/utils/csv.py
+++ b/collectives/utils/csv.py
@@ -13,8 +13,7 @@ class PlaceholderFiller:
     def __call__(self, match):
         key = match.group(1)
         if key in self.row.keys():
-            return self.row[key].replace('\\', '\\\\').replace(
-                '"', '\\"').replace("\n", '\\n')
+            return self.row[key]
         return ''
 
 

--- a/collectives/utils/export.py
+++ b/collectives/utils/export.py
@@ -36,36 +36,6 @@ class DefaultLayout:
         return '{c}{r}'.format(r=self.REGISTRATION_START_ROW+index, c=column)
 
 
-def strip_tags(ops):
-    """
-    Very naive parsing on quill deltas
-    Keep only plain text and bullet lists 
-    """
-    tags = json.loads(ops)
-
-    text = ''
-    chunk = ''
-
-    for op in tags['ops']:
-        # Attributes refer to the previous chunk of text
-        pattern = '{}'
-        if 'attributes' in op.keys():
-            for attr, value in op['attributes'].items():
-                if attr == 'list' and value == 'bullet':
-                    pattern = '- {}'
-
-        # Apply attributes to current chunk
-        text += pattern.format(chunk)
-
-        # Grab next chunk
-        chunk = ''
-        if 'insert' in op.keys():
-            chunk = op['insert']
-
-    text += chunk
-
-    return text
-
 
 def to_xlsx(event, cells=DefaultLayout()):
     wb = load_workbook(filename=current_app.config['XLSX_TEMPLATE'])
@@ -79,7 +49,7 @@ def to_xlsx(event, cells=DefaultLayout()):
 
     # Title, Description
     ws[cells.TITLE] = event.title
-    ws[cells.DESCRIPTION] = strip_tags(event.description)
+    ws[cells.DESCRIPTION] = event.description
 
     # Leader(s)
     leader_names = [l.full_name() for l in event.leaders]

--- a/config.py
+++ b/config.py
@@ -80,85 +80,21 @@ IMAGES_CACHE = os.path.join(basedir, "collectives/static/uploads/cache")
 IMAGES_PATH = ["static/uploads", "static/uploads/avatars"]
 
 
-DESCRIPTION_TEMPLATE = """{
-    \"ops\":[
-        {
-            \"insert\":\"ITINERAIRE: \"
-        },
-        {
-            \"attributes\":{
-                \"header\":2
-            },
-            \"insert\":\"\\n\"
-        },
-        {
-            \"insert\":\"\\nAltitude max.:  \"
-        },
-        {
-            \"attributes\":{
-                \"header\":2
-            },
-            \"insert\":\"$altitude$\\n\"
-        },
-        {
-            \"insert\":\"∆+:  \"
-        },
-        {
-            \"attributes\":{
-                \"header\":2
-            },
-            \"insert\":\"$denivele$\\n\"
-        },
-        {
-            \"insert\":\"Cotation: \"
-        },
-        {
-            \"attributes\":{
-                \"header\":2
-            },
-            \"insert\":\"$cotation$\\n\"
-        },
-        {
-            \"insert\":\"\\nLIEU ET HEURE DE DEPART: \"
-        },
-        {
-            \"attributes\":{
-                \"header\":2
-            },
-            \"insert\":\"\\n\"
-        },
-        {
-            \"insert\":\"\\nMATERIEL REQUIS:\"
-        },
-        {
-            \"attributes\":{
-                \"header\":2
-            },
-            \"insert\":\"\\n\"
-        },
-        {
-            \"insert\":\"Equipement1\"
-        },
-        {
-            \"attributes\":{
-                \"list\":\"bullet\"
-            },
-            \"insert\":\"\\n\"
-        },
-        {
-            \"insert\":\"Equipement2\"
-        },
-        {
-            \"attributes\":{
-                \"list\":\"bullet\"
-            },
-            \"insert\":\"\\n\"
-        },
-        {
-            \"insert\":\"$observations$\"
-        }
-    ]
-}"""
+DESCRIPTION_TEMPLATE = """
+## Itinéraire:
+**Altitude max** : $altitude$
+**Dénivelé** : $denivele$
+**Cotation** : $cotation$
+
+## Lieu et heure de départ
+
+## Matériel requis
+ - Équipement 1
+ - Équipement 2
+
+## Observations
+$observations$
+"""
 
 XLSX_TEMPLATE = os.path.join(basedir,
                              "collectives/templates/exported_event.xlsx")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ flask-marshmallow
 flask-testing
 marshmallow-sqlalchemy
 Flask-Images
-quill-delta[html]
+markdown
 pylint
 pylint-quotes
 pylint-flask-sqlalchemy


### PR DESCRIPTION
Prototype de remplacement de Quill par un éditeur markdown "semi-WYSIWYG"
+ ajout de lien automatique sur les URL

Les avantages sont un format de texte beaucoup plus lisible, facile à manipuler et à corriger en cas de fausse manip, ainsi qu'un plus large support Python