### PR TITLE
Event: add date validation during event management

### DIFF
--- a/collectives/static/js/event/edit.js
+++ b/collectives/static/js/event/edit.js
@@ -170,17 +170,17 @@ function checkDateOrder(){
     // End of registration is before start of event
     // Nothing if no value
     const dateorder2 = document.getElementById("dateorder2");
-    if(registration_close_time.value != "" && new Date(registration_close_time.value) > new Date(start.value) ) {
+    if(registration_close_time.value != "" && new Date(registration_close_time.value) > new Date(end.value) ) {
         dateorder2.style.display = "inline";
         registration_close_time.setCustomValidity('Mauvais ordre des dates');
-        start.setCustomValidity('Mauvais ordre des dates');
+        end.setCustomValidity('Mauvais ordre des dates');
         // Quit to avoid resetting pattern later
         return false;
     }
     else{
         dateorder2.style.display = "none";
         registration_close_time.setCustomValidity('');
-        start.setCustomValidity('');
+        end.setCustomValidity('');
     }
 
     // End of registration is before start of event

--- a/collectives/static/js/event/edit.js
+++ b/collectives/static/js/event/edit.js
@@ -110,3 +110,94 @@ function makeEditor(elementId)
     simplemde.options.promptTexts = { "link": "Adresse du lien", "image": "Adresse de l'image" };
     return simplemde;
 }
+
+function validateDateTime(element){
+    if (element.value != "" && isNaN(new Date(element.value).getDay())){
+        element.setCustomValidity('Doit être une date');
+        return false;
+    }
+    element.setCustomValidity('');
+    return true;
+}
+
+function checkDateOrder(){
+    const start = document.getElementById('start');
+    const end = document.getElementById('end');
+    const registration_open_time = document.getElementById('registration_open_time');
+    const registration_close_time = document.getElementById('registration_close_time');
+
+    // Don't check order if a Date is not validated
+    var validation =    validateDateTime(start) &&
+                        validateDateTime(end) &&
+                        validateDateTime(registration_open_time) &&
+                        validateDateTime(registration_close_time);
+    if( ! validation )
+        return false;
+
+    // If a registration bound is defined, check the other one definition
+    const halfregistration = document.getElementById("halfregistration");
+    if(     ( registration_open_time.value == "" && registration_close_time.value != "" )
+        ||  ( registration_open_time.value != "" && registration_close_time.value == "" )){
+        halfregistration.style.display = "inline";
+        registration_close_time.setCustomValidity('Doit être défini');
+        registration_open_time.setCustomValidity('Doit être défini');
+        // Quit to avoid resetting pattern later
+        return false;
+    }
+    else{
+        halfregistration.style.display = "none";
+        registration_close_time.setCustomValidity('');
+        registration_open_time.setCustomValidity('');
+    }
+
+
+    // Start of event is before end of it
+    const dateorder1 = document.getElementById("dateorder1");
+    if( new Date(start.value) > new Date(end.value) ){
+        dateorder1.style.display = "inline";
+        start.setCustomValidity('Mauvais ordre des dates');
+        end.setCustomValidity('Mauvais ordre des dates');
+        // Quit to avoid resetting pattern later
+        return false;
+    }
+    else{
+        dateorder1.style.display = "none";
+        start.setCustomValidity('');
+        end.setCustomValidity('');
+    }
+
+
+    // End of registration is before start of event
+    // Nothing if no value
+    const dateorder2 = document.getElementById("dateorder2");
+    if(registration_close_time.value != "" && new Date(registration_close_time.value) > new Date(start.value) ) {
+        dateorder2.style.display = "inline";
+        registration_close_time.setCustomValidity('Mauvais ordre des dates');
+        start.setCustomValidity('Mauvais ordre des dates');
+        // Quit to avoid resetting pattern later
+        return false;
+    }
+    else{
+        dateorder2.style.display = "none";
+        registration_close_time.setCustomValidity('');
+        start.setCustomValidity('');
+    }
+
+    // End of registration is before start of event
+    // Nothing if no value
+    const dateorder3 = document.getElementById("dateorder3");
+    if(registration_open_time.value != "" && registration_close_time.value != "" && new Date(registration_close_time.value) < new Date(registration_open_time.value) ){
+        dateorder3.style.display = "inline";
+        registration_close_time.setCustomValidity('Mauvais ordre des dates');
+        registration_open_time.setCustomValidity('Mauvais ordre des dates');
+        // Quit to avoid resetting pattern later
+        return false;
+    }
+    else{
+        dateorder3.style.display = "none";
+        registration_close_time.setCustomValidity('');
+        registration_open_time.setCustomValidity('');
+    }
+
+    return true;
+}

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -46,15 +46,31 @@
 
     <div class="dates">
       <h4>Dates</h4>
-      <span class="datetimepicker" id="datetimepickerstart"><label for="start" onchange="copyStartDate();">Date et heure de rendez-vous : </label>{{ form.start(onchange="copyStartDate()")}}</span>
-      <span class="datetimepicker" id="datetimepickerend"><label for="end" >Date de fin : </label>{{ form.end }}</span>
+      <span class="datetimepicker" id="datetimepickerstart"><label for="start">Date et heure de rendez-vous : </label>{{ form.start(onchange="copyStartDate(); checkDateOrder();")}}</span>
+      <span class="datetimepicker" id="datetimepickerend"><label for="end" >Date de fin : </label>{{ form.end(onchange="checkDateOrder();") }}</span>
+      <b id="dateorder1" style="display: none"><br/>
+          <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-warning.svg') }}"  alt="Attention: "/>
+          La date de début d'évènement doit être antérieure à la fin
+      </b>
     </div>
 
     <div class="dates">
       <h4>Inscriptions par internet</h4>
       <label for="num_online_slots">Nombre de participants internet : </label> {{ form.num_online_slots(size=4) }}<br/>
-      <span class="datetimepicker" id="datetimepicker_open"><label for="registration_open_time" >Ouverture des inscriptions : </label>{{ form.registration_open_time}}</span>
-      <span class="datetimepicker" id="datetimepicker_close" ><label for="registration_close_time" >Fermeture des inscriptions : </label>{{ form.registration_close_time }}</span>
+      <span class="datetimepicker" id="datetimepicker_open"><label for="registration_open_time" >Ouverture des inscriptions : </label>{{ form.registration_open_time(onchange="checkDateOrder();")}}</span>
+      <span class="datetimepicker" id="datetimepicker_close" ><label for="registration_close_time" >Fermeture des inscriptions : </label>{{ form.registration_close_time(onchange="checkDateOrder();") }}</span>
+      <b id="halfregistration" style="display: none"><br/>
+          <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-warning.svg') }}"  alt="Attention: "/>
+          Vous devez définir le début et la fin des inscriptions
+      </b>
+      <b id="dateorder2" style="display: none"><br/>
+          <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-warning.svg') }}"  alt="Attention: "/>
+          La date de fin d'inscription doit être antérieure au début de l'évènement
+      </b>
+      <b id="dateorder3" style="display: none"><br/>
+          <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-warning.svg') }}"  alt="Attention: "/>
+          La date de début d'inscription doit être antérieure à la fin de l'inscription
+      </b>
     </div>
 
     <h4>Description</h4>

--- a/collectives/templates/editevent.html
+++ b/collectives/templates/editevent.html
@@ -65,7 +65,7 @@
       </b>
       <b id="dateorder2" style="display: none"><br/>
           <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-warning.svg') }}"  alt="Attention: "/>
-          La date de fin d'inscription doit être antérieure au début de l'évènement
+          La date de fin d'inscription doit être antérieure à la fin de l'évènement
       </b>
       <b id="dateorder3" style="display: none"><br/>
           <img class="icon" src="{{ url_for('static', filename='img/icon/ionicon/md-warning.svg') }}"  alt="Attention: "/>


### PR DESCRIPTION
Ajout de la validation des dates:
https://trello.com/c/eoxmtzRm/99-cr%C3%A9ation-collective-validation-des-champs-de-type-date
- vérification qu'il s'agit d'une vraie Date
- la fin des inscriptions par internet doivent être antérieures à la date de début de la collective
- les dates de fin doivent être postérieures aux dates de début
- les dates d'inscriptions par internet ne peuvent plus être remplies à moitié