### PR TITLE
Use server data in "end" filter

### DIFF
--- a/collectives/api.py
+++ b/collectives/api.py
@@ -11,6 +11,7 @@ from .models import ActivityType, Registration, RegistrationStatus
 import json
 
 from .utils.access import confidentiality_agreement, admin_required
+from .helpers import current_time
 
 marshmallow = Marshmallow()
 blueprint = Blueprint('api', __name__, url_prefix='/api')
@@ -294,15 +295,14 @@ def events():
         filter = None
         if field == 'activity_type':
             filter = Event.activity_types.any(short=value)
-        if field == 'end' or field == 'status':
-            if type == "=":
-                filter = getattr(Event, field) == value
+        elif field == 'end' :
             if type == ">=":
-                filter = getattr(Event, field) >= value
-            if type == "<=":
-                filter = getattr(Event, field) <= value
-            if type == "!=":
-                filter = getattr(Event, field) != value
+                filter = Event.end >= current_time()
+        elif field == 'status': 
+            if type == "=":
+                filter = Event.status == value
+            elif type == "!=":
+                filter = Event.status != value
 
         if filter is not None:
             query = query.filter(filter)

--- a/collectives/static/js/event/eventlist.js
+++ b/collectives/static/js/event/eventlist.js
@@ -37,7 +37,7 @@ window.onload = function(){
             pageLoaded :  updatePageURL,
 
             initialSort: [ {column:"start", dir:"asc"}],
-            initialFilter: [{field:"end", type:">=", value:getServerLocalTime() }], 
+            initialFilter: [{field:"end", type:">=", value:"now" }], 
   			columns:[
       			{title:"Titre", field:"title", sorter:"string"},
                 {title:"Date", field:"start", sorter:"string"},
@@ -191,7 +191,7 @@ function toggleActivity(activity_id, element){
 function togglePastActivities(element){
 
     if ( ! element.checked){
-        eventsTable.addFilter( [{field:"end", type:">=", value:getServerLocalTime() }]);
+        eventsTable.addFilter( [{field:"end", type:">=", value:"now" }]);
     }else{
         endfilter=eventsTable.getFilters().filter(function(i ){ return i['field'] == "end" });
         eventsTable.removeFilter(endfilter);


### PR DESCRIPTION
Always use current server date for "end" filter
Compatible with existing persistent filters