### PR TITLE
Mail: add Date and message ID field. Add DKIM. Should fix #135

### DIFF
--- a/collectives/utils/mail.py
+++ b/collectives/utils/mail.py
@@ -2,7 +2,7 @@ import smtplib, dkim
 from flask import current_app
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from email import utils
+import email
 import unicodedata
 
 # To use it:
@@ -20,8 +20,8 @@ def send_mail(**kwargs):
 
     msg['From'] = config['SMTP_ADDRESS']
     msg['Subject'] = kwargs['subject']
-    msg['Message-ID'] = utils.make_msgid(domain=config['SERVER_NAME'])
-    msg['Date'] = utils.formatdate()
+    msg['Message-ID'] = email.utils.make_msgid(domain=config['SERVER_NAME'])
+    msg['Date'] = email.utils.formatdate()
 
     dest = kwargs['email']
     if isinstance(dest, list):

--- a/config.py
+++ b/config.py
@@ -38,7 +38,9 @@ SMTP_HOST = environ.get('SMTP_HOST') or 'smtp.example.org'
 SMTP_PORT = environ.get('SMTP_PORT') or 25
 SMTP_ADDRESS = environ.get('SMTP_ADDRESS') or 'noreply@example.org'
 SMTP_PASSWORD = environ.get('SMTP_PASSWORD') or ''
-
+# Empty DKIM_KEY or DKIM_SELECTOR disable DKIM signature
+DKIM_KEY = ""
+DKIM_SELECTOR = "default"
 
 # Page information
 TITLE = "Collectives CAF Annecy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ openpyxl
 # See Issue #98
 Werkzeug==0.16.1
 pymysql
+dkimpy


### PR DESCRIPTION
Conformément aux tests de mail tester, il manquait des headers:

- Message-id
- Date
- DKIM-Signature

A noter que la signature DKIM est désactivée s'il n'y a pas les paramètres DKIM_KEY et DKIM_SIGNATURE dans la configuration.